### PR TITLE
Support express v4 and npm install, npm start

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ for incoming authentication.  Set the `consumer key` to the same value that you 
 Provide a matching RSA public key for the private key in use in your NodeJS application and finally configure a callback
 url that will redirect to `<NodeJS base URL>/auth/atlassian-oauth/callback` (given the example above). 
 
-To generate a usable private and public RSA key set you can use the following commands:
+To generate a usable private and public RSA key set you can use the following commands from [Jira knowledge base](https://confluence.atlassian.com/jirakb/how-to-generate-public-key-to-application-link-3rd-party-applications-913214098.html):
 
     openssl genrsa -out jira.pem 1024
     openssl rsa -in jira.pem -pubout -out jira.pub

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ accepts these credentials and calls `done` providing a user, as well as
 `options` specifying a applicationURL, consumerKey, and callback URL.
 
     passport.use(new AtlassianOAuthStrategy({
-            applicationURL:"http://localhost:2990/jira",
-            callbackURL:"http://localhost:5000/auth/atlassian-oauth/callback",
-            consumerKey:"atlassian-oauth-sample",
+            applicationURL:"http://localhost:2990/jira", // This is the Jira server url
+            callbackURL:"http://localhost:5000/auth/atlassian-oauth/callback", // Your node instance
+            consumerKey:"atlassian-oauth-sample", 
             consumerSecret:"<RSA private key>",
       },
       function(token, tokenSecret, profile, done) {
@@ -66,10 +66,16 @@ for incoming authentication.  Set the `consumer key` to the same value that you 
 Provide a matching RSA public key for the private key in use in your NodeJS application and finally configure a callback
 url that will redirect to `<NodeJS base URL>/auth/atlassian-oauth/callback` (given the example above). 
 
+To generate a usable private and public RSA key set you can use the following commands:
+
+    openssl genrsa -out jira.pem 1024
+    openssl rsa -in jira.pem -pubout -out jira.pub
+
 
 ## Examples
 
-For a complete, working example, refer to the [login example](https://bitbucket.org/knecht_andreas/passport-atlassian-oauth/src/master/examples/login).
+For a complete, working example, refer to the [login example](https://github.com/timcosta/passport-atlassian-oauth/tree/master/examples/login).
+You can `npm install` in that directory to set up express and dependencies, and `npm start` to start the server example script.
 
 ## Issues
 

--- a/examples/login/app.js
+++ b/examples/login/app.js
@@ -84,7 +84,8 @@ app.set('views', __dirname + '/views');
 app.set('view engine', 'ejs');
 app.use(logger('dev'));
 app.use(cookieParser());
-app.use(bodyParser({ extended: false }));
+app.use(bodyParser.urlencoded({ extended: false }));
+app.use(bodyParser.json());
 app.use(methodOverride());
 app.use(session({ secret:'keyboard cat', resave: false, saveUninitialized: false }));
 // Initialize Passport!  Also use passport.session() middleware, to support

--- a/examples/login/app.js
+++ b/examples/login/app.js
@@ -1,8 +1,15 @@
 var express = require('express'),
     http = require('http'),
     passport = require('passport'),
-    util = require('util'),
-    AtlassianOAuthStrategy = require('../../').Strategy;
+    AtlassianOAuthStrategy = require('passport-atlassian-oauth').Strategy,
+    logger = require('morgan'),
+    session = require('express-session'),
+    path = require('path'),
+    cookieParser = require('cookie-parser'),
+    methodOverride = require('method-override'),
+    serveStatic = require('serve-static'),
+    router = express.Router(),
+    bodyParser = require('body-parser');
 
 // Passport session setup.
 //   To support persistent login sessions, Passport needs to be able to
@@ -44,12 +51,12 @@ var RsaPublicKey = "-----BEGIN PUBLIC KEY-----\n" +
     "yLOfY8XZvnFkGjipvQIDAQAB\n" +
     "-----END PUBLIC KEY-----";
 
-
 // Use the AtlassianOauthStrategy within Passport.
 //   Strategies in Passport require a `verify` function, which accept
 //   credentials (in this case, a token, tokenSecret, and Atlassian
 //   profile), and invoke a callback with a user object.
-passport.use(new AtlassianOAuthStrategy({
+passport.use(new AtlassianOAuthStrategy(
+    {
         applicationURL:"http://localhost:2990/jira",
         callbackURL:"http://localhost:5000/auth/atlassian-oauth/callback",
         consumerKey:"atlassian-oauth-sample",
@@ -72,22 +79,21 @@ passport.use(new AtlassianOAuthStrategy({
 var app = express();
 
 // configure Express
-app.configure(function () {
-    app.set('port', process.env.PORT || 5000);
-    app.set('views', __dirname + '/views');
-    app.set('view engine', 'ejs');
-    app.use(express.logger());
-    app.use(express.cookieParser());
-    app.use(express.bodyParser());
-    app.use(express.methodOverride());
-    app.use(express.session({ secret:'keyboard cat' }));
-    // Initialize Passport!  Also use passport.session() middleware, to support
-    // persistent login sessions (recommended).
-    app.use(passport.initialize());
-    app.use(passport.session());
-    app.use(app.router);
-    app.use(express.static(__dirname + '/public'));
-});
+app.set('port', process.env.PORT || 5000);
+app.set('views', __dirname + '/views');
+app.set('view engine', 'ejs');
+app.use(logger('dev'));
+app.use(cookieParser());
+app.use(bodyParser({ extended: false }));
+app.use(methodOverride());
+app.use(session({ secret:'keyboard cat', resave: false, saveUninitialized: false }));
+// Initialize Passport!  Also use passport.session() middleware, to support
+// persistent login sessions (recommended).
+app.use(passport.initialize());
+app.use(passport.session());
+app.use(router);
+app.use(serveStatic(__dirname + '/public'));
+
 
 
 app.get('/', function (req, res) {

--- a/examples/login/package.json
+++ b/examples/login/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "passport-atlassian-oauth-login-example",
+  "version": "1.0.0",
+  "description": "Working example provided in the passport-atlassian-oauth package. Updated for express 4.",
+  "main": "app.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node app.js"
+  },
+  "author": "Original author: Andreas Knecht. Example updates: Kevin Vanderbeken",
+  "license": "MIT",
+  "dependencies": {
+    "cookie-parser": "^1.4.4",
+    "ejs": "^2.6.1",
+    "express": "^4.17.1",
+    "express-session": "^1.16.1",
+    "http": "0.0.0",
+    "method-override": "^3.0.0",
+    "morgan": "^1.9.1",
+    "passport": "^0.4.0",
+    "passport-atlassian-oauth": "^0.0.2",
+    "util": "^0.12.0"
+  }
+}

--- a/examples/login/views/index.ejs
+++ b/examples/login/views/index.ejs
@@ -1,5 +1,7 @@
 <% if (!user) { %>
 	<h2>Welcome! Please log in.</h2>
+	<a href="/login">Login</a>
 <% } else { %>
 	<h2>Hello, <%= user.username %>.</h2>
+	<a href="/account">Account details</a>
 <% } %>


### PR DESCRIPTION
This now installs deps and works under express 4 changes, to allow users to run the example from this “login” directory easily.
Updates the documentation to give a few handy hints, including addressing #1 