### PR TITLE
Updated Atlassian user call to use accountId instead of username

### DIFF
--- a/lib/passport-atlassian-oauth/strategy.js
+++ b/lib/passport-atlassian-oauth/strategy.js
@@ -1,9 +1,9 @@
 /**
  * Module dependencies.
  */
-var util = require('util')
-    , OAuthStrategy = require('passport-oauth').OAuthStrategy
-    , InternalOAuthError = require('passport-oauth').InternalOAuthError;
+var util = require('util'),
+    OAuthStrategy = require('passport-oauth').OAuthStrategy,
+    InternalOAuthError = require('passport-oauth').InternalOAuthError;
 
 
 /**
@@ -42,8 +42,8 @@ var util = require('util')
  */
 function Strategy(options, verify) {
     options = options || {};
-    if (!options.applicationURL)  throw new Error('Atlassian Oauth Strategy requires a applicationURL option');
-    if (!options.callbackURL)  throw new Error('Atlassian Oauth Strategy requires a callbackURL option');
+    if (!options.applicationURL) throw new Error('Atlassian Oauth Strategy requires a applicationURL option');
+    if (!options.callbackURL) throw new Error('Atlassian Oauth Strategy requires a callbackURL option');
 
     options.requestTokenURL = options.requestTokenURL || options.applicationURL + '/plugins/servlet/oauth/request-token';
     options.accessTokenURL = options.accessTokenURL || options.applicationURL + '/plugins/servlet/oauth/access-token';
@@ -81,7 +81,7 @@ util.inherits(Strategy, OAuthStrategy);
  */
 Strategy.prototype.userProfile = function (token, tokenSecret, params, done) {
     var self = this;
-    self._oauth._performSecureRequest(token, tokenSecret, "GET", this._applicationURL + "/rest/auth/1/session", null, "", "application/json", function (err, body, res) {
+    self._oauth._performSecureRequest(token, tokenSecret, "GET", this._applicationURL + "/rest/api/2/myself", null, "", "application/json", function (err, body, res) {
         if (err) {
             return done(new InternalOAuthError('failed to fetch user profile', err));
         }
@@ -89,7 +89,7 @@ Strategy.prototype.userProfile = function (token, tokenSecret, params, done) {
         try {
             var json = JSON.parse(body);
 
-            var jiraProfileResource = self._applicationURL + "/rest/api/2/user?expand=groups&username=" + json.name;
+            var jiraProfileResource = self._applicationURL + "/rest/api/2/user?expand=groups&accountId=" + json.accountId;
             self._oauth._performSecureRequest(token, tokenSecret, "GET", jiraProfileResource, null, "", "application/json", function (err, body, res) {
                 if (err) {
                     return done(new InternalOAuthError('failed to fetch user profile', err));
@@ -97,15 +97,17 @@ Strategy.prototype.userProfile = function (token, tokenSecret, params, done) {
 
                 try {
                     var json = JSON.parse(body);
-                    var profile = { provider:'atlassian-oauth' };
-                    profile.id = json.name;
-                    profile.username = json.name;
+                    var profile = {
+                        provider: 'atlassian-oauth'
+                    };
+                    profile.id = json.accountId;
+                    profile.username = json.emailAddress;
                     profile.displayName = json.displayName;
                     profile.avatarUrls = json.avatarUrls;
                     profile.timeZone = json.timeZone;
-                    profile.emails = [
-                        { value:json.emailAddress }
-                    ];
+                    profile.emails = [{
+                        value: json.emailAddress
+                    }];
 
                     var groups = [];
                     for (var i = 0; i < json.groups.items.length; i++) {


### PR DESCRIPTION
I was getting an error from the `/rest/api/2/user?expand=groups&username=` call that said the `accountId` parameter was required. I refactored a bit to use the `accountId` instead.